### PR TITLE
Add min-release-age to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=10 # days


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `min-release-age=10` (days) at the repo root
- Enforces a project-level minimum release age on npm packages to mitigate supply chain risks from recently-published compromised releases
- Mirrors the user-level setting configured via the internal `setup-supply-chain-mitigations.sh` script

Note: this repo has many sub-projects under `part*/` with their own `package.json`. npm's project `.npmrc` is resolved from cwd, so running `npm install` from a sub-project directory may not pick this up. Happy to add `.npmrc` into each sub-project in a follow-up if you want full coverage — your user-level `~/.npmrc` already protects local runs either way.

## Test plan
- [ ] Confirm `npm install` at the repo root still works
- [ ] Verify `.npmrc` is picked up (`npm config get min-release-age` from repo root)